### PR TITLE
Initial commit, Alpha release

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This Plugin is an extension for the [Teams for WooCommerce Memberships](https://woocommerce.com/products/teams-woocommerce-memberships/) plugin.
 
-It enablres automatically assigning newly registered Users to existing WooComm Team Memberships based on their email domain.
+It automatically assigns newly registered Users to existing WooComm Team Memberships based on their email domain.
 
 If a new User has an email with a domain that matches the email domain of an Team Membership Owner, this new User will automatically get assigned to their Team.
 

--- a/README.md
+++ b/README.md
@@ -1,29 +1,27 @@
 # Newspack Teams for WooCommerce Memberships Auto-Join by Email
 
-This Plugin is an extension for the Teams for WooCommerce Memberships plugin.
+This Plugin is an extension for the [Teams for WooCommerce Memberships](https://woocommerce.com/products/teams-woocommerce-memberships/) plugin.
 
-It automatically assigns newly registered Users to existing WooComm Team Memberships based on their email domain.
+It enablres automatically assigning newly registered Users to existing WooComm Team Memberships based on their email domain.
 
-If a new User's email domain matches the email domain of the Team Membership's Owner, the User will automatically get assigned to that Team.
+If a new User has an email with a domain that matches the email domain of an Team Membership Owner, this new User will automatically get assigned to their Team.
 
 ## Usage
 
-This plugin adds a simple settings Section to the `WooCommerce` > `Settings` > `Memberships`, called "Teams Auto-Join by Email".
+The plugin adds a simple settings Section to the `WooCommerce` > `Settings` > `Memberships`, called "Teams Auto-Join by Email".
 
-These settings enable you to specify the "Excluded Email Domains". The Excluded Domains are email domains which get ignored/excluded from this logic. 
+The settings enable defining "Excluded Email Domains". These are email domains are email domains which will get ignored/excluded when checking the new User's email domain. 
 
-For example, if there is a Team Membership Owner with a `@gmail.com` domain, you will almost certainly want to add `gmail.com` to this list, so that newly registered users with `@gmail.com` email do not get added to this Membership.
+For example, if there is a Team Membership Owner with the `@gmail.com` email domain, you will almost certainly want to add `gmail.com` to your Excluded Email Domains list, to prevent new Users with `@gmail.com` emails being added to a Team Membership which might have an Owner with a `@gmail.com` email too.
 
-The list is Coma Separated Value formatted, and enables use of the `*` qualifier.
-
-For example, if you enter these two entries as Excluded Email Domains:
+The Excluded Email Domains list supports the use of the `*` qualifier. For example, if you entered these two entries:
 
 ```
 gmail.com,yahoo.*
 ```
 
-the Plugin will ignore all newly registered users with all the `@yahoo.*` extensions too, e.g. `@yahoo.com`, `@yahoo.co.uk`, ...
+the Plugin will then ignore all new Users with all the `@yahoo.*` possible emails too, e.g. `@yahoo.com`, `@yahoo.co.uk`, ...
 
 ### Security Recommendations
 
-Since this Plugin automatically adds new Users to existing Team Memberships, it is recommended to enable email verification for new Users before registration is activated.
+Since this Plugin automatically adds new Users to existing Team Memberships, it is recommended to enable email verification for all new Users before their registration is confirmed.


### PR DESCRIPTION
This is an initial release for a new repo. Check out the brief [README](https://github.com/Automattic/newspack-teams-for-wc-memberships-auto-join-by-email/blob/master/README.md).

Kindly asking for a thorough review of this initial commit. I pushed this Alpha directly to `master`, and created this dummy branch so that I may create a PR based on something. Please review the full content of the `master` including:
- project setup: scaffolding, PHP, config review
- plugin and PHP code
- do a test run of the steps below

## This plugin

This plugin works on top of the [Teams for WooCommerce Memberships](https://woocommerce.com/products/teams-woocommerce-memberships/), and it introduces one specific functionality -- automatically assigns a newly registered User to an existing Team Membership based on their email -- if the new User's email domain matches the email domain of the Team Membership Owner, they will get assigned to that particular Team.

## Test site setup

- any WP site, Newspack is not required
- install "WooCommerce", "WooCommerce Membersips" and "WooCommerce Teams for Memberships"
- run the WooCommerce Setup Wizard, simply so that it creates the WooComm pages -- enter the address, and fill the minimum number of fields to get through the Wizard successfully
- simply activate this plugin (no building required)

### Configure the test site:
- go to Dashboard > WooCommerce > Settings > Accounts & Privacy, and enable the "Allow customers to create an account on the "My account" page" feature. But you may actually check all of these checkboxes, just to simplify things a bit, because I skipped checking whether just this one checkbox is enough (although it should be):
![image](https://user-images.githubusercontent.com/29167323/86265400-08922100-bbc4-11ea-85dc-5029c0749d33.png)
- next go to Dashboard > WooCommerce > Memberships > Membership Plans, and add one dummy Plan -- no specific configuration needed, just give it a title
- then go to Dashboard > WooCommerce > Memberships > Teams, and click "Add Team" -- also no specific config needed:
  - here in the Team Details side bar, **simply make note of the Owner's email** -- I'm using a default test site, and my admin account `admin@local.test` has been auto-assigned as the Owner, so that's the email I'm writing down. You'll need this email domain for the next tests

### Test auto-join by email works:
- open an incognito window, and access the WooComm My Account page (on my blank site, permalinks are set to use IDs, so I had to go to All Pages and get the link from there)
- there should be a Register field there, since we've enabled it in Settings
- use a fake email with identical email domain as the Team Membership's owner -- I'm going to use `user.auto.joins@local.test`
- click Register
- finally go to Dashboard > WooCommerce > Memberships > Teams, edit your test Team, and confirm that the user has been added as a member

### Test Excluded/Ignored email domains work:
- next head to WooCommerce > Settings > Memberships and open the "Teams Auto-Join by Email" section
- in "Excluded Email Domains" enter the very same email domain which you just used, and we'll next check that the following user with that same email domain is no longer auto-added. I'll add several more CSV entries, among which is my targeted one. I'm adding: `gmail.com,yahoo.*,local.test` -- notice that there's the `*` option too, and you may test it as well if you'd like, after completing this test run
- repeat registering a new user with the same domain, and confirm that the new user has not been added to the Team Membership this time