### PR TITLE
Add check to handle case where team doesn't have an owner

### DIFF
--- a/plugin/class-plugin.php
+++ b/plugin/class-plugin.php
@@ -166,7 +166,11 @@ class Plugin {
 
 		// Compare if any of the Team Membership Owners has the same email domain as this users.
 		foreach ( $teams as $team ) {
-			$team_owner              = $team->get_owner();
+			$team_owner = $team->get_owner();
+			if ( ! $team_owner ) {
+				continue;
+			}
+
 			$team_owner_email_domain = $this->get_domain_from_email( $team_owner->get( 'user_email' ) );
 			if ( false === $team_owner_email_domain ) {
 				continue;


### PR DESCRIPTION
This PR fixes an issue that was affecting one of our customers (ping me for which). When a user registers for the site at the `/my-account` page, the user was getting created, however a fatal error was getting thrown:

```
PHP Fatal error:  Uncaught Error: Call to a member function get() on bool in /srv/htdocs/wp-content/plugins/newspack-teams-for-wc-memberships-auto-join-by-email/plugin/class-plugin.php:170
```

I'm not sure how to reproduce locally, but deploying this patch to their site solved the issue. Apparently some teams don't have an owner?